### PR TITLE
Add push notifications for payment success (customer + agent)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ const {
 const transporter = require("./utils/transporter.js");
 const PrintJob = require("./models/print-job-schema.js");
 const otpGenerator = require("otp-generator");
+const { sendPushNotification } = require("./utils/pushNotifications.js");
 
 
 
@@ -126,6 +127,49 @@ app.post(
             // Don't fail the payment process if chat creation fails
           }
 
+          // Send push notifications to customer and print agent
+          try {
+            const amount = (paymentIntent.amount / 100).toFixed(2);
+
+            await sendPushNotification(customer._id, "customer", {
+              title: "Payment successful 🎉",
+              body: `Your payment of $${amount} was successful.`,
+              data: {
+                type: "payment_success",
+                print_job_id: printJob._id.toString(),
+                amount,
+              },
+            });
+
+            await sendPushNotification(customer._id, "customer", {
+              title: "Job created successfully",
+              body: `"${printJob.print_job_title}" ($${amount}) sent to ${printAgent.business_name}. Pickup code: ${confirmationCode}`,
+              data: {
+                type: "job_created",
+                print_job_id: printJob._id.toString(),
+                agent_business_name: printAgent.business_name,
+                amount,
+                confirmation_code: confirmationCode,
+              },
+            });
+
+            await sendPushNotification(printAgent._id, "printAgent", {
+              title: "New Job received",
+              body: `New order "${printJob.print_job_title}" ($${amount}) is ready to print.`,
+              data: {
+                type: "new_paid_order",
+                print_job_id: printJob._id.toString(),
+                amount,
+              },
+            });
+          } catch (notifyError) {
+            console.error(
+              "Error sending payment success notifications:",
+              notifyError.message,
+            );
+            // Don't fail the payment flow if notifications fail
+          }
+
           console.log("Payment successful, emails sent, chat session created.");
         } catch (err) {
           console.error("Error processing payment success:", err.message);
@@ -133,6 +177,40 @@ app.post(
 
         break;
       }
+
+      // TODO: Enable once "payment_intent.payment_failed" is added in the
+      // Stripe Dashboard webhook events. Sends a "Payment failed" push to the
+      // customer. Commented out for now.
+      // case "payment_intent.payment_failed": {
+      //   const paymentIntent = event.data.object;
+      //
+      //   try {
+      //     const customerId = paymentIntent.metadata.customer_id;
+      //     const printJobId = paymentIntent.metadata.print_job_id;
+      //
+      //     if (customerId) {
+      //       const printJob = printJobId
+      //         ? await PrintJob.findById(printJobId)
+      //         : null;
+      //       const jobTitle = printJob ? printJob.print_job_title : "your order";
+      //
+      //       await sendPushNotification(customerId, "customer", {
+      //         title: "Payment failed ❌",
+      //         body: `Your payment for "${jobTitle}" could not be completed. Please try again.`,
+      //         data: {
+      //           type: "payment_failed",
+      //           print_job_id: printJobId || "",
+      //         },
+      //       });
+      //     }
+      //
+      //     console.log("Payment failed notification sent.");
+      //   } catch (err) {
+      //     console.error("Error processing payment failure:", err.message);
+      //   }
+      //
+      //   break;
+      // }
 
       default:
         console.log(`Unhandled event type ${event.type}`);
@@ -160,6 +238,7 @@ app.use("/api/printjob", printJobRoutes);
 app.use("/api/kiosk", kioskRoutes);
 app.use("/api/chat", chatRoutes);
 app.use("/api/banner", require("./routes/bannerRoutes.js"));
+app.use("/api/notifications", require("./routes/notificationRoutes.js"));
 
 
 

--- a/src/models/notification-token-schema.js
+++ b/src/models/notification-token-schema.js
@@ -1,0 +1,49 @@
+const mongoose = require("mongoose");
+
+const notificationTokenSchema = new mongoose.Schema({
+  user_id: {
+    type: mongoose.Schema.Types.ObjectId,
+    required: true,
+    refPath: "user_type_ref",
+  },
+  user_type: {
+    type: String,
+    enum: ["customer", "printAgent"],
+    required: true,
+  },
+  device_token: {
+    type: String,
+    required: true,
+    unique: true,
+  },
+  platform: {
+    type: String,
+    enum: ["ios", "android", "mobile", "web"],
+    default: "mobile",
+  },
+  is_active: {
+    type: Boolean,
+    default: true,
+  },
+  created_at: { type: Date, default: Date.now },
+  updated_at: { type: Date, default: Date.now },
+});
+
+// Map user_type to the correct model for refPath population
+notificationTokenSchema.virtual("user_type_ref").get(function () {
+  return this.user_type === "printAgent" ? "PrintAgent" : "Customer";
+});
+
+notificationTokenSchema.index({ user_id: 1, user_type: 1, is_active: 1 });
+
+notificationTokenSchema.pre("save", function (next) {
+  this.updated_at = Date.now();
+  next();
+});
+
+const NotificationToken = mongoose.model(
+  "NotificationToken",
+  notificationTokenSchema,
+);
+
+module.exports = NotificationToken;

--- a/src/routes/notificationRoutes.js
+++ b/src/routes/notificationRoutes.js
@@ -1,0 +1,67 @@
+const express = require("express");
+const verifyToken = require("../middleware/verifyToken.js");
+const {
+  registerNotificationToken,
+  unregisterNotificationToken,
+} = require("../utils/pushNotifications.js");
+
+const router = express.Router();
+
+// POST /api/notifications/register-token
+// Body: { device_token, platform? }
+// Works for both customers and print agents (role comes from JWT)
+router.post("/register-token", verifyToken(), async (req, res) => {
+  try {
+    const { device_token, platform } = req.body;
+
+    if (!device_token) {
+      return res.status(400).json({ message: "device_token is required" });
+    }
+
+    // req.user.role is "customer" or "printAgent" (set by verifyToken)
+    const userType = req.user.role;
+    if (userType !== "customer" && userType !== "printAgent") {
+      return res
+        .status(400)
+        .json({ message: "Notifications are only available for app users" });
+    }
+
+    const token = await registerNotificationToken(
+      req.user.id,
+      userType,
+      device_token,
+      platform || "mobile",
+    );
+
+    res.status(200).json({
+      message: "Notification token registered successfully",
+      token_id: token._id,
+    });
+  } catch (err) {
+    console.error("Error registering notification token:", err.message);
+    res.status(500).json({ message: "Server error", err: err.message });
+  }
+});
+
+// POST /api/notifications/unregister-token
+// Body: { device_token }  — call on logout
+router.post("/unregister-token", verifyToken(), async (req, res) => {
+  try {
+    const { device_token } = req.body;
+
+    if (!device_token) {
+      return res.status(400).json({ message: "device_token is required" });
+    }
+
+    await unregisterNotificationToken(device_token);
+
+    res
+      .status(200)
+      .json({ message: "Notification token unregistered successfully" });
+  } catch (err) {
+    console.error("Error unregistering notification token:", err.message);
+    res.status(500).json({ message: "Server error", err: err.message });
+  }
+});
+
+module.exports = router;

--- a/src/routes/printjobRoutes.js
+++ b/src/routes/printjobRoutes.js
@@ -94,6 +94,10 @@ router.post(
 
       await printJob.save();
 
+      // Note: the customer "Job created successfully" notification (with price,
+      // agent name and pickup code) is sent on payment_intent.succeeded in
+      // index.js, because the agent is only selected after this step.
+
       res
         .status(201)
         .json({ message: "Print job created successfully", printJob });


### PR DESCRIPTION
- New NotificationToken model + register/unregister routes (/api/notifications)
- Send Expo push on payment_intent.succeeded: customer gets "Payment successful" + "Job created successfully" (price, agent, pickup code); agent gets "New Job received" (price)
- payment_intent.payment_failed handler added but commented out until the event is enabled in the Stripe Dashboard